### PR TITLE
Cleaning up artist id

### DIFF
--- a/src/containers/ReleaseDetail/index.js
+++ b/src/containers/ReleaseDetail/index.js
@@ -49,7 +49,7 @@ class ReleaseDetail extends Component {
                                 {this.state.item.release_title}
                             </div>
                             <div className='artists'>
-                                {this.state.item.fk_artist}
+                                {this.state.item.artist}
                             </div>
                             <div className='release_num'>                            {this.state.item.cat_num}
                             </div>


### PR DESCRIPTION
- Release tile previously used fk_artist, but category is redundant so it's being removed from the data files